### PR TITLE
Improve reliability by fast forwarding

### DIFF
--- a/content_youtube.js
+++ b/content_youtube.js
@@ -5,6 +5,7 @@
         const adElement = document.querySelector('.video-ads.ytp-ad-module');
         if (video && adElement && adElement.children.length > 0) {
             muteAndSpeedUp(video, 16.0)
+            video.currentTime = video.currentTime + 1;
         }
         // Skip button seems to be acessible at initialization, if its ever present
         const skipButton = document.querySelector('.ytp-ad-skip-button, .ytp-ad-skip-button-modern, .ytp-skip-ad-button');


### PR DESCRIPTION
Because of how the code works, this will add one second to the video over and over again until the ad ends.